### PR TITLE
Fix #47: guard module-level CLI behind __main__

### DIFF
--- a/generate_ruml.py
+++ b/generate_ruml.py
@@ -344,30 +344,31 @@ def call_generate_ruml(source_code_link, **kwargs):
     )
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("github_repository", type=str,
-                    help="generate RUML for the given Github repository which contains the source code")
-parser.add_argument("-u", "--use_case", type=str,
-                    help="generate use case for the source code")
-parser.add_argument("-d", "--driver_name", type=str,
-                    help="name of the driver module for the given use case")
-parser.add_argument("-dp", "--driver_path", type=str,
-                    help="file path of the driver module for the given use case")
-parser.add_argument('-df', '--driver_function', type=str,
-                    help="function name to be executed for the given use case")
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("github_repository", type=str,
+                        help="generate RUML for the given Github repository which contains the source code")
+    parser.add_argument("-u", "--use_case", type=str,
+                        help="generate use case for the source code")
+    parser.add_argument("-d", "--driver_name", type=str,
+                        help="name of the driver module for the given use case")
+    parser.add_argument("-dp", "--driver_path", type=str,
+                        help="file path of the driver module for the given use case")
+    parser.add_argument('-df', '--driver_function', type=str,
+                        help="function name to be executed for the given use case")
 
-args = parser.parse_args()
-source_code_link = args.github_repository
-if args.use_case:
-    if not args.driver_name or not args.driver_path or not args.driver_function:
-        raise ValueError(
-            'Use case set to be true but driver details not provided. Please type "python3 gruml-cli.py --help for details."')
+    args = parser.parse_args()
+    source_code_link = args.github_repository
+    if args.use_case:
+        if not args.driver_name or not args.driver_path or not args.driver_function:
+            raise ValueError(
+                'Use case set to be true but driver details not provided. Please type "python3 gruml-cli.py --help for details."')
+        else:
+            use_case = args.use_case
+            driver_name = args.driver_name
+            driver_path = args.driver_path
+            driver_function = args.driver_function
+        call_generate_ruml(source_code_link, use_case=use_case,
+                           driver_name=driver_name, driver_path=driver_path, driver_function=driver_function)
     else:
-        use_case = args.use_case
-        driver_name = args.driver_name
-        driver_path = args.driver_path
-        driver_function = args.driver_function
-    call_generate_ruml(source_code_link, use_case=use_case,
-                       driver_name=driver_name, driver_path=driver_path, driver_function=driver_function)
-else:
-    call_generate_ruml(source_code_link)
+        call_generate_ruml(source_code_link)


### PR DESCRIPTION
## Summary
- Wrap the bottom-of-file argparse + dispatch block in `if __name__ == '__main__':` so importing `generate_ruml` no longer triggers a full pipeline run as a side effect.

## Baseline (master) reproduces the bug
Running `python3 gruml-cli.py /path/to/local/checkout` on master gives a traceback where `call_generate_ruml(source_code_link)` is called from `generate_ruml.py:373` *during* `gruml-cli.py:7` (`from generate_ruml import gruml`):

```
File "/.../gruml-cli.py", line 7, in <module>
    from generate_ruml import gruml
File "/.../generate_ruml.py", line 373, in <module>
    call_generate_ruml(source_code_link)
```

After the fix, the same `from generate_ruml import gruml` is a pure import: `gruml` is callable, `GRUML` is a usable class, no I/O happens.

## Test plan
- [x] `python3 -c "from generate_ruml import gruml; print(callable(gruml))"` returns `True` with no clone / no parse_args
- [x] `python3 generate_ruml.py --help` still prints the CLI help (so direct invocation works)
- [x] Indentation is the only behavioural change — every argparse arg and the `call_generate_ruml` dispatch is preserved

Closes #47.
