### PR TITLE
Fix #49: use module_name in intra-file dependency loop

### DIFF
--- a/generate_ruml.py
+++ b/generate_ruml.py
@@ -213,7 +213,7 @@ class GRUML:
         for file_ in files.keys():
             module_name = file_.replace(
                 '/', '.')[len(self.source_code_path[0])+1:].split('.py')[0]
-            if module not in self.source_code_modules:
+            if module_name not in self.source_code_modules:
                 continue
             with open(file_) as f:
                 data = f.read()


### PR DESCRIPTION
## Summary
- One-character fix at `generate_ruml.py:216`: the intra-file dependency loop computes `module_name` from each file path but checked the leftover `module` from the previous (inter-file) loop.

## Baseline (master) shows the bug

```python
# Inter-file loop ends with `module` bound to the last file's module.
# Intra-file loop:
for file_ in files.keys():
    module_name = file_.replace(...)        # correct value for this iteration
    if module not in self.source_code_modules:   # checks the LEAKED `module`
        continue
```

Effect on master: the intra-file loop either processes every file (if the leaked `module` happens to be in scope) or skips every file. Same-file class-to-class dependencies are recorded incorrectly.

## Test plan
- [x] Diff is the single token `module` → `module_name`
- [x] `from generate_ruml import gruml` still imports without side effects

Closes #49.
