### PR TITLE
Fix #46: safe open() in dependency scanning

### DIFF
--- a/generate_ruml.py
+++ b/generate_ruml.py
@@ -166,7 +166,8 @@ class GRUML:
                 continue
             for j in files.keys():
                 try:
-                    source = open(j).read()
+                    with open(j, encoding='utf-8', errors='replace') as f:
+                        source = f.read()
                     collector = ModuleUseCollector(module)
                     collector.visit(ast.parse(source))
                     for use_ in collector.used_at:
@@ -215,7 +216,7 @@ class GRUML:
                 '/', '.')[len(self.source_code_path[0])+1:].split('.py')[0]
             if module_name not in self.source_code_modules:
                 continue
-            with open(file_) as f:
+            with open(file_, encoding='utf-8', errors='replace') as f:
                 data = f.read()
                 module = ast.parse(data)
                 classes = [obj for obj in module.body if isinstance(


### PR DESCRIPTION
## Summary
- Replace `source = open(j).read()` at `generate_ruml.py:169` with `with open(..., encoding='utf-8', errors='replace')`.
- Add the same explicit encoding to the existing `with open(file_)` on line 218.

## Why
- The bare `open(j).read()` leaks the file handle until GC.
- Both reads relied on the platform default encoding, which is locale-dependent and not UTF-8 on every host. Python source is UTF-8 by PEP 3120, so we should say so explicitly.
- `errors='replace'` means a stray non-UTF-8 byte produces U+FFFD instead of crashing the whole pipeline; the AST parser is happy with the replacement character.

## Test plan
- [x] Diff is two open() call sites; no other logic changes
- [x] `from generate_ruml import gruml` still works
- [x] Manual: created a Latin-1 source file in a fixture; before this change the run crashed with `UnicodeDecodeError`, after it proceeds

Closes #46.
