### PR TITLE
Fix #48: replace module-level foo global with instance attribute

### DIFF
--- a/generate_ruml.py
+++ b/generate_ruml.py
@@ -18,8 +18,6 @@ from generate_sequence_diagram import GenerateSequenceDiagram
 from plot_uml_in_excel import WriteInExcel
 from utils_google_drive import upload_file_to_google_drive
 
-foo = None
-
 logging.basicConfig(level=logging.ERROR)
 
 
@@ -33,8 +31,10 @@ class GRUML:
         self.test = test
         self.use_case = True
         self.class_object_mapping = defaultdict(dict)
-        global foo
-        self.foo = foo
+        # Dynamically-loaded driver module for use-case tracing; populated
+        # by generate_sequential_function_calls. Previously a module-level
+        # global named `foo` (see #48).
+        self.driver_module = None
         self.sys_path_folders = set()
 
     def get_source_code_path_and_modules(self, source_code_path):
@@ -267,12 +267,12 @@ class GRUML:
         #     self.driver_path, self.driver_name, self.source_code_path[0])
         spec = importlib.util.spec_from_file_location(
             self.driver_name, self.driver_path)
-        global foo
-        foo = self.foo
-        foo = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(foo)
+        self.driver_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.driver_module)
         tracer = Trace(countfuncs=1, countcallers=1, timing=1)
-        tracer.run('foo.{}()'.format(self.driver_function))
+        # Use runfunc + getattr so the driver function name does not need
+        # to be string-interpolated into a code blob executed by Trace.run.
+        tracer.runfunc(getattr(self.driver_module, self.driver_function))
         results = tracer.results()
         caller_functions = results.callers
         function_sequence = []  # consists of all functions called in sequence


### PR DESCRIPTION
## Summary
- Drop module-level `foo = None`.
- Drop the two `global foo` / `self.foo = foo` paths inside `GRUML`.
- Store the dynamically-loaded driver module on `self.driver_module`.
- Switch the trace call from `tracer.run('foo.{}()'.format(...))` (string interpolation, eval in globals) to `tracer.runfunc(getattr(self.driver_module, self.driver_function))`.

## Why
The `foo` global existed only because `Trace.run(str)` evaluates its argument in the module's global namespace, so `foo` had to be importable by name from inside the executed string. Using `Trace.runfunc(callable)` takes the function directly and removes the indirection.

This is also a prerequisite for #45 (exec injection): once we're passing a real callable, the next PR can layer on a strict identifier check.

## Test plan
- [x] `from generate_ruml import gruml; from generate_ruml import GRUML; GRUML()` shows `driver_module = None` and **no** `self.foo` attribute
- [x] No remaining references to the bare name `foo` anywhere in `generate_ruml.py`
- [x] Diff is local to the two affected sites + module-level constant; no behavioural changes anywhere else

Closes #48.
