### PR TITLE
Fix #45: validate driver_function against an identifier whitelist

### DIFF
--- a/generate_ruml.py
+++ b/generate_ruml.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 import os
 import pyclbr
+import re
 import shutil
 import sys
 from collections import defaultdict
@@ -19,6 +20,13 @@ from plot_uml_in_excel import WriteInExcel
 from utils_google_drive import upload_file_to_google_drive
 
 logging.basicConfig(level=logging.ERROR)
+
+# Whitelist of safe driver-function identifiers. The function name is fed to
+# importlib + getattr at runtime; the AttributeError path is already safe
+# against code injection (getattr does not parse its argument), but rejecting
+# anything that is not a plain Python identifier produces a clearer error and
+# guards future code that might interpret driver_function as a code blob.
+_SAFE_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class GRUML:
@@ -61,6 +69,11 @@ class GRUML:
         if not use_case:
             self.use_case = False
             return
+        if not _SAFE_IDENTIFIER.match(driver_function or ""):
+            raise ValueError(
+                "driver_function {!r} is not a valid Python identifier "
+                "(must match [A-Za-z_][A-Za-z0-9_]*)".format(driver_function)
+            )
         self.use_case = use_case
         self.driver_name = driver_name
         self.driver_path = os.path.join(self.source_code_path[0], driver_path)


### PR DESCRIPTION
## Summary
- Reject any `driver_function` that is not a plain Python identifier (regex `^[A-Za-z_][A-Za-z0-9_]*\$`) inside `get_driver_path_and_driver_name`, raising `ValueError` with a clear message.

## Context
#48 already removed the string-interpolated `tracer.run('foo.{}()'.format(...))` call site and replaced it with `tracer.runfunc(getattr(self.driver_module, self.driver_function))`, which on its own neutralises the original injection vector (`getattr` does not parse its argument as code).

This PR is **defense in depth**:
- A garbage / malicious driver_function now fails fast with a clear error rather than producing an opaque AttributeError later.
- Anything that *does* later consume `self.driver_function` in a different way (eval, Trace.run, subprocess, etc.) cannot reintroduce the injection without going through the regex first.

## Reproducer

```python
g = GRUML()
g.source_code_path = ['/x']
g.get_driver_path_and_driver_name(
    use_case='evil',
    driver_name='d', driver_path='d.py',
    driver_function='main(); __import__(\"os\").system(\"echo pwned\")',
)
# Before:
#   silently accepted; getattr later raises AttributeError
# After:
#   ValueError: driver_function "main(); ..." is not a valid Python identifier
```

## Test plan
- [x] `driver_function='main'` is accepted (regression check)
- [x] `driver_function='main(); ...'` is rejected with ValueError
- [x] Diff: one import, one constant, one guard — no other code paths touched

Closes #45.
