### PR TITLE
Fix #77: pin Dockerfile base to ubuntu:20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8


### PR DESCRIPTION
## Summary
- One-line change: \`FROM ubuntu:latest\` → \`FROM ubuntu:20.04\`.

## Why
\`ubuntu:latest\` has drifted past the assumptions the rest of the Dockerfile makes:
- Legacy \`/usr/share/locale/locale.alias\` is missing → \`localedef\` step crashes.
- Hardcoded \`/usr/lib/python3.8/pyclbr.py\` patch path only exists on Python 3.8 (ubuntu:20.04).

Pinning to \`ubuntu:20.04\` makes the existing locale install, python3.8, and pyclbr-stdlib-patch all line up again. No other changes needed.

## Verification
\`\`\`bash
docker build --platform linux/amd64 -t gruml .
docker run --platform linux/amd64 -d --name gruml gruml
docker exec gruml python3 gruml-cli.py \\
    https://github.com/kebab-mai-haddi/python3-class-inheritance-dependency-example
\`\`\`
- Build succeeds end-to-end.
- \`Dependency_2.xlsx\` is produced with all car/vehicle classes: \`Bike, Car, Vehicle, BikePollutionPermit, CarPollutionPermit, TractorPollutionPermit, TractorPesticides, Dummy\`, methods, and arrows \`← ⇒ ▷ ◁\`.
- Use-case run \`-u test_cli -d driver -dp driver.py -df main_2\` produces \`Use_Case_test_cliDependency_2.xlsx\` (30×26) with sequence arrows \`→ ←\`.

\`--platform linux/amd64\` is required on Apple Silicon because the 2020-era pinned numpy/pandas wheels do not have aarch64 builds. A follow-up issue covers updating the pinned deps so native arm64 works.

Closes #77.